### PR TITLE
Fix for NSRangeException, attempting to remove observer twice.

### DIFF
--- a/VGParallaxHeader/UIScrollView+VGParallaxHeader.m
+++ b/VGParallaxHeader/UIScrollView+VGParallaxHeader.m
@@ -279,9 +279,11 @@ static void *VGParallaxHeaderObserverContext = &VGParallaxHeaderObserverContext;
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
     if (self.superview && newSuperview == nil) {
-        [self.superview removeObserver:self
-                            forKeyPath:NSStringFromSelector(@selector(contentInset))
-                               context:VGParallaxHeaderObserverContext];
+        if ([self.superview respondsToSelector:@selector(contentInset)]) {
+            [self.superview removeObserver:self
+                                forKeyPath:NSStringFromSelector(@selector(contentInset))
+                                   context:VGParallaxHeaderObserverContext];
+        }
     }
 }
 


### PR DESCRIPTION
This was attempting to remove the observer twice and throwing an exception when loading a subclass of VGParallaxHeader attached to a .xib file.

`'Cannot remove an observer <NEShowDetailHeaderView 0x13650a150> for the key path "contentInset" from <UIView 0x17018d680> because it is not registered as an observer.'`