### PR TITLE
Rename UIScrollView.parallaxHeader property because of naming conflicts with MXParallaxHeader pod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,240 @@
+##################################################
+# 		MY ADDINGS
+##################################################
+
+#####
+# Project specific ignored files:
+# .....
+
+#### 
+# Example of keeping empty folder
+
+## Leave folder CopiedFromTargetFolder under git control by tracking one unchanged file .keep
+#/clients/infosnapper/infosnapper/Resources/CopiedFromTargetFolder/*
+#!/clients/infosnapper/infosnapper/Resources/CopiedFromTargetFolder/.keep
+
+##################################################
+# 	FROM https://gist.github.com/adamgit/3786883
+##################################################
+
+#########################
+# .gitignore file for Xcode4 and Xcode5 Source projects
+#
+# Apple bugs, waiting for Apple to fix/respond:
+#
+#    15564624 - what does the xccheckout file in Xcode5 do? Where's the documentation?
+#
+# Version 2.3
+# For latest version, see: http://stackoverflow.com/questions/49478/git-ignore-file-for-xcode-projects
+#
+# 2014 updates:
+# - appended non-standard items DISABLED by default (uncomment if you use those tools)
+# - removed the edit that an SO.com moderator made without bothering to ask me
+# - researched CocoaPods .lock more carefully, thanks to Gokhan Celiker
+# 2013 updates:
+# - fixed the broken "save personal Schemes"
+# - added line-by-line explanations for EVERYTHING (some were missing)
+#
+# NB: if you are storing "built" products, this WILL NOT WORK,
+# and you should use a different .gitignore (or none at all)
+# This file is for SOURCE projects, where there are many extra
+# files that we want to exclude
+#
+#########################
+
+#####
+# OS X temporary files that should never be committed
+#
+# c.f. http://www.westwind.com/reference/os-x/invisibles.html
+
+.DS_Store
+
+# c.f. http://www.westwind.com/reference/os-x/invisibles.html
+
+.Trashes
+
+# c.f. http://www.westwind.com/reference/os-x/invisibles.html
+
+*.swp
+
+#
+# *.lock - this is used and abused by many editors for many different things.
+#    For the main ones I use (e.g. Eclipse), it should be excluded 
+#    from source-control, but YMMV.
+#   (lock files are usually local-only file-synchronization on the local FS that should NOT go in git)
+# c.f. the "OPTIONAL" section at bottom though, for tool-specific variations!
+
+# Ignoring Podfile.lock is cancelled below
+*.lock
+
+
+
+#
+# profile - REMOVED temporarily (on double-checking, I can't find it in OS X docs?)
+#profile
+
+
+####
+# Xcode temporary files that should never be committed
+# 
+# NB: NIB/XIB files still exist even on Storyboard projects, so we want this...
+
+*~.nib
+
+
+####
+# Xcode build files -
+#
+# NB: slash on the end, so we only remove the FOLDER, not any files that were badly named "DerivedData"
+
+DerivedData/
+
+# NB: slash on the end, so we only remove the FOLDER, not any files that were badly named "build"
+
+build/
+
+
+#####
+# Xcode private settings (window sizes, bookmarks, breakpoints, custom executables, smart groups)
+#
+# This is complicated:
+#
+# SOMETIMES you need to put this file in version control.
+# Apple designed it poorly - if you use "custom executables", they are
+#  saved in this file.
+# 99% of projects do NOT use those, so they do NOT want to version control this file.
+#  ..but if you're in the 1%, comment out the line "*.pbxuser"
+
+# .pbxuser: http://lists.apple.com/archives/xcode-users/2004/Jan/msg00193.html
+
+*.pbxuser
+
+# .mode1v3: http://lists.apple.com/archives/xcode-users/2007/Oct/msg00465.html
+
+*.mode1v3
+
+# .mode2v3: http://lists.apple.com/archives/xcode-users/2007/Oct/msg00465.html
+
+*.mode2v3
+
+# .perspectivev3: http://stackoverflow.com/questions/5223297/xcode-projects-what-is-a-perspectivev3-file
+
+*.perspectivev3
+
+#    NB: also, whitelist the default ones, some projects need to use these
+!default.pbxuser
+!default.mode1v3
+!default.mode2v3
+!default.perspectivev3
+
+
+####
+# Xcode 4 - semi-personal settings
+#
+#
+# OPTION 1: ---------------------------------
+#     throw away ALL personal settings (including custom schemes!
+#     - unless they are "shared")
+#
+# NB: this is exclusive with OPTION 2 below
+xcuserdata
+
+# OPTION 2: ---------------------------------
+#     get rid of ALL personal settings, but KEEP SOME OF THEM
+#     - NB: you must manually uncomment the bits you want to keep
+#
+# NB: this *requires* git v1.8.2 or above; you may need to upgrade to latest OS X,
+#    or manually install git over the top of the OS X version
+# NB: this is exclusive with OPTION 1 above
+#
+#xcuserdata/**/*
+
+#     (requires option 2 above): Personal Schemes
+#
+#!xcuserdata/**/xcschemes/*
+
+####
+# XCode 4 workspaces - more detailed
+#
+# Workspaces are important! They are a core feature of Xcode - don't exclude them :)
+#
+# Workspace layout is quite spammy. For reference:
+#
+# /(root)/
+#   /(project-name).xcodeproj/
+#     project.pbxproj
+#     /project.xcworkspace/
+#       contents.xcworkspacedata
+#       /xcuserdata/
+#         /(your name)/xcuserdatad/
+#           UserInterfaceState.xcuserstate
+#     /xcsshareddata/
+#       /xcschemes/
+#         (shared scheme name).xcscheme
+#     /xcuserdata/
+#       /(your name)/xcuserdatad/
+#         (private scheme).xcscheme
+#         xcschememanagement.plist
+#
+#
+
+####
+# Xcode 4 - Deprecated classes
+#
+# Allegedly, if you manually "deprecate" your classes, they get moved here.
+#
+# We're using source-control, so this is a "feature" that we do not want!
+
+*.moved-aside
+
+####
+# OPTIONAL: Some well-known tools that people use side-by-side with Xcode / iOS development
+#
+# NB: I'd rather not include these here, but gitignore's design is weak and doesn't allow
+#     modular gitignore: you have to put EVERYTHING in one file.
+#
+# COCOAPODS:
+#
+# c.f. http://guides.cocoapods.org/using/using-cocoapods.html#what-is-a-podfilelock
+# c.f. http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+#Pods/
+!Podfile.lock
+#
+# RUBY:
+#
+# c.f. http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
+#
+#!Gemfile.lock
+#
+# IDEA:
+#
+#.idea
+#
+# TEXTMATE:
+#
+# -- UNVERIFIED: c.f. http://stackoverflow.com/a/50283/153422
+#
+#tm_build_errors
+
+####
+# UNKNOWN: recommended by others, but I can't discover what these files are
+#
+# Community suggestions (unverified, no evidence available - DISABLED by default)
+#
+# 1. Xcode 5 - VCS file
+#
+# "The data in this file not represent state of your project.
+# If you'll leave this file in git - you will have merge conflicts during 
+# pull your cahnges to other's repo"
+#
+# Some discussions can be found here http://stackoverflow.com/questions/18340453/should-xccheckout-files-in-xcode5-be-ignored-under-vcs?lq=1
+# The best explanation I think here: http://stackoverflow.com/questions/18340453/should-xccheckout-files-in-xcode5-be-ignored-under-vcs/19260712#19260712
+# in place with words "if you are using a DVCS"
+#
+*.xccheckout
+
+####
+#
+# Recommended to add in here: https://github.com/github/gitignore/blob/master/Objective-C.gitignore
+*.xcscmblueprint

--- a/Example/Example/FirstTableViewController.m
+++ b/Example/Example/FirstTableViewController.m
@@ -30,8 +30,8 @@
     stickyLabel.textAlignment = NSTextAlignmentCenter;
     stickyLabel.text = @"Say hello to Sticky View :)";
     
-    self.tableView.parallaxHeader.stickyViewPosition = VGParallaxHeaderStickyViewPositionTop;
-    [self.tableView.parallaxHeader setStickyView:stickyLabel
+    self.tableView.vg_parallaxHeader.stickyViewPosition = VGParallaxHeaderStickyViewPositionTop;
+    [self.tableView.vg_parallaxHeader setStickyView:stickyLabel
                                       withHeight:40];
 }
 

--- a/Example/Example/FirstViewController.m
+++ b/Example/Example/FirstViewController.m
@@ -31,11 +31,11 @@
     stickyLabel.textAlignment = NSTextAlignmentCenter;
     stickyLabel.text = @"Say hello to Sticky View :)";
     
-    self.scrollView.parallaxHeader.stickyViewPosition = VGParallaxHeaderStickyViewPositionTop;
-    [self.scrollView.parallaxHeader setStickyView:stickyLabel
+    self.scrollView.vg_parallaxHeader.stickyViewPosition = VGParallaxHeaderStickyViewPositionTop;
+    [self.scrollView.vg_parallaxHeader setStickyView:stickyLabel
                                       withHeight:40];
     
-    self.scrollView.parallaxHeader.backgroundColor = [UIColor lightGrayColor];
+    self.scrollView.vg_parallaxHeader.backgroundColor = [UIColor lightGrayColor];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle

--- a/Example/Example/SecondTableViewController.m
+++ b/Example/Example/SecondTableViewController.m
@@ -36,7 +36,7 @@
 {
     [self.tableView shouldPositionParallaxHeader];
     
-    CGFloat ratio = fmaxf(0, scrollView.parallaxHeader.progress - 1);
+    CGFloat ratio = fmaxf(0, scrollView.vg_parallaxHeader.progress - 1);
     self.headerView.backgroundColor = [UIColor colorForFadeBetweenFirstColor:[UIColor colorWithRed:0.59 green:0.85 blue:0.27 alpha:1]
                                                                  secondColor:[UIColor colorWithRed:0.86 green:0.09 blue:0.13 alpha:1]
                                                                      atRatio:ratio];

--- a/Example/Example/SecondViewController.m
+++ b/Example/Example/SecondViewController.m
@@ -32,8 +32,8 @@
     stickyLabel.textAlignment = NSTextAlignmentCenter;
     stickyLabel.text = @"Say hello to Sticky View :)";
     
-    self.scrollView.parallaxHeader.stickyViewPosition = VGParallaxHeaderStickyViewPositionBottom;
-    [self.scrollView.parallaxHeader setStickyView:stickyLabel
+    self.scrollView.vg_parallaxHeader.stickyViewPosition = VGParallaxHeaderStickyViewPositionBottom;
+    [self.scrollView.vg_parallaxHeader setStickyView:stickyLabel
                                       withHeight:40];
     
     
@@ -45,7 +45,7 @@
     [self.scrollView shouldPositionParallaxHeader];
 
     // This is how you can implement appearing or disappearing of sticky view
-    [scrollView.parallaxHeader.stickyView setAlpha:scrollView.parallaxHeader.progress];
+    [scrollView.vg_parallaxHeader.stickyView setAlpha:scrollView.vg_parallaxHeader.progress];
 }
 
 - (void)viewDidLayoutSubviews

--- a/VGParallaxHeader/UIScrollView+VGParallaxHeader.h
+++ b/VGParallaxHeader/UIScrollView+VGParallaxHeader.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, VGParallaxHeaderShadowBehaviour) {
 
 @interface UIScrollView (VGParallaxHeader)
 
-@property (nonatomic, strong, readonly) VGParallaxHeader *parallaxHeader;
+@property (nonatomic, strong, readonly) VGParallaxHeader *vg_parallaxHeader;
 
 - (void)setParallaxHeaderView:(UIView *)view
                          mode:(VGParallaxHeaderMode)mode

--- a/VGParallaxHeader/UIScrollView+VGParallaxHeader.m
+++ b/VGParallaxHeader/UIScrollView+VGParallaxHeader.m
@@ -63,18 +63,18 @@ static void *VGParallaxHeaderObserverContext = &VGParallaxHeaderObserverContext;
                        height:(CGFloat)height
 {
     // New VGParallaxHeader
-    self.parallaxHeader = [[VGParallaxHeader alloc] initWithScrollView:self
+    self.vg_parallaxHeader = [[VGParallaxHeader alloc] initWithScrollView:self
                                                            contentView:view
                                                                   mode:mode
                                                                 height:height];
     
-    self.parallaxHeader.headerHeight = height;
+    self.vg_parallaxHeader.headerHeight = height;
     
     // Calling this to position everything right
     [self shouldPositionParallaxHeader];
     
     // If UIScrollView adjust inset
-    if (!self.parallaxHeader.isInsideTableView) {
+    if (!self.vg_parallaxHeader.isInsideTableView) {
         UIEdgeInsets selfContentInset = self.contentInset;
         selfContentInset.top += height;
         
@@ -83,7 +83,7 @@ static void *VGParallaxHeaderObserverContext = &VGParallaxHeaderObserverContext;
     }
     
     // Watch for inset changes
-    [self addObserver:self.parallaxHeader
+    [self addObserver:self.vg_parallaxHeader
            forKeyPath:NSStringFromSelector(@selector(contentInset))
               options:NSKeyValueObservingOptionNew
               context:VGParallaxHeaderObserverContext];
@@ -94,24 +94,24 @@ static void *VGParallaxHeaderObserverContext = &VGParallaxHeaderObserverContext;
     CGFloat newContentInset = 0;
     UIEdgeInsets selfContentInset = self.contentInset;
     
-    if (height < self.parallaxHeader.headerHeight) {
-        newContentInset = self.parallaxHeader.headerHeight - height;
+    if (height < self.vg_parallaxHeader.headerHeight) {
+        newContentInset = self.vg_parallaxHeader.headerHeight - height;
         selfContentInset.top -= newContentInset;
     } else {
-        newContentInset = height - self.parallaxHeader.headerHeight;
+        newContentInset = height - self.vg_parallaxHeader.headerHeight;
         selfContentInset.top += newContentInset;
     }
     
     self.contentInset = selfContentInset;
     self.contentOffset = CGPointMake(0, -selfContentInset.top);
     
-    self.parallaxHeader.headerHeight = height;
-    [self.parallaxHeader setNeedsLayout];
+    self.vg_parallaxHeader.headerHeight = height;
+    [self.vg_parallaxHeader setNeedsLayout];
 }
 
 - (void)shouldPositionParallaxHeader
 {
-    if(self.parallaxHeader.isInsideTableView) {
+    if(self.vg_parallaxHeader.isInsideTableView) {
         [self positionTableViewParallaxHeader];
     }
     else {
@@ -121,35 +121,35 @@ static void *VGParallaxHeaderObserverContext = &VGParallaxHeaderObserverContext;
 
 - (void)positionTableViewParallaxHeader
 {
-    CGFloat scaleProgress = fmaxf(0, (1 - ((self.contentOffset.y + self.parallaxHeader.originalTopInset) / self.parallaxHeader.originalHeight)));
-    self.parallaxHeader.progress = scaleProgress;
+    CGFloat scaleProgress = fmaxf(0, (1 - ((self.contentOffset.y + self.vg_parallaxHeader.originalTopInset) / self.vg_parallaxHeader.originalHeight)));
+    self.vg_parallaxHeader.progress = scaleProgress;
     
-    if (self.contentOffset.y < self.parallaxHeader.originalHeight) {
+    if (self.contentOffset.y < self.vg_parallaxHeader.originalHeight) {
         // We can move height to if here because its uitableview
-        CGFloat height = self.contentOffset.y * -1 + self.parallaxHeader.originalHeight;
+        CGFloat height = self.contentOffset.y * -1 + self.vg_parallaxHeader.originalHeight;
         // Im not 100% sure if this will only speed up VGParallaxHeaderModeCenter
         // but on other modes it can be visible. 0.5px
-        if (self.parallaxHeader.mode == VGParallaxHeaderModeCenter) {
+        if (self.vg_parallaxHeader.mode == VGParallaxHeaderModeCenter) {
             height = round(height);
         }
         // This is where the magic is happening
-        self.parallaxHeader.containerView.frame = CGRectMake(0, self.contentOffset.y, CGRectGetWidth(self.frame), height);
+        self.vg_parallaxHeader.containerView.frame = CGRectMake(0, self.contentOffset.y, CGRectGetWidth(self.frame), height);
     }
 }
 
 - (void)positionScrollViewParallaxHeader
 {
     CGFloat height = self.contentOffset.y * -1;
-    CGFloat scaleProgress = fmaxf(0, (height / (self.parallaxHeader.originalHeight + self.parallaxHeader.originalTopInset)));
-    self.parallaxHeader.progress = scaleProgress;
+    CGFloat scaleProgress = fmaxf(0, (height / (self.vg_parallaxHeader.originalHeight + self.vg_parallaxHeader.originalTopInset)));
+    self.vg_parallaxHeader.progress = scaleProgress;
     
     if (self.contentOffset.y < 0) {
         // This is where the magic is happening
-        self.parallaxHeader.frame = CGRectMake(0, self.contentOffset.y, CGRectGetWidth(self.frame), height);
+        self.vg_parallaxHeader.frame = CGRectMake(0, self.contentOffset.y, CGRectGetWidth(self.frame), height);
     }
 }
 
-- (void)setParallaxHeader:(VGParallaxHeader *)parallaxHeader
+- (void)setVg_parallaxHeader:(VGParallaxHeader *)parallaxHeader
 {
     // Remove All Subviews
     if([self.subviews count] > 0) {
@@ -175,7 +175,7 @@ static void *VGParallaxHeaderObserverContext = &VGParallaxHeaderObserverContext;
     objc_setAssociatedObject(self, &UIScrollViewVGParallaxHeader, parallaxHeader, OBJC_ASSOCIATION_ASSIGN);
 }
 
-- (VGParallaxHeader *)parallaxHeader
+- (VGParallaxHeader *)vg_parallaxHeader
 {
     return objc_getAssociatedObject(self, &UIScrollViewVGParallaxHeader);
 }


### PR DESCRIPTION
As you can see on the following screenshot http://take.ms/RsgTR MXParallaxHeader pod is also using `parallaxHeader` name for property on UIScrollView. I experience troubles using the both pods in my project. Could you rename property being added library specific prefix, for example "vg" as I have done in this pull request.